### PR TITLE
Fix: Connect SIMD/FP free_list empty_o to pipeline stall

### DIFF
--- a/includes/drac_pkg.sv
+++ b/includes/drac_pkg.sv
@@ -923,6 +923,8 @@ typedef struct packed {
     logic simd_out_of_checkpoints;      // SIMD Rename out of checkpoints
     logic fp_out_of_checkpoints;        // FP Rename out of checkpoints
     logic empty_free_list;              // Free list out of registers
+    logic simd_empty_free_list;         // SIMD free list out of registers
+    logic fp_empty_free_list;           // FP free list out of registers
     logic is_branch;                    // Rename instruction is a branch
 } ir_cu_t;      // Rename to Control Unit
 

--- a/rtl/control_unit/rtl/control_unit.sv
+++ b/rtl/control_unit/rtl/control_unit.sv
@@ -421,7 +421,7 @@ module control_unit
             pipeline_flush_o.flush_ir  = 1'b0;
             pipeline_flush_o.flush_rr  = 1'b1;
             pipeline_flush_o.flush_exe = 1'b0;
-        end else if (ir_cu_i.empty_free_list) begin
+        end else if (ir_cu_i.empty_free_list || ir_cu_i.simd_empty_free_list || ir_cu_i.fp_empty_free_list) begin
             pipeline_flush_o.flush_ir  = 1'b0;
             pipeline_flush_o.flush_rr  = 1'b0;
             pipeline_flush_o.flush_exe = 1'b0;
@@ -487,7 +487,7 @@ module control_unit
             pipeline_ctrl_o.stall_ir  = 1'b1;
             pipeline_ctrl_o.stall_rr  = 1'b1;
             pipeline_ctrl_o.stall_exe = 1'b0;
-        end else if (ir_cu_i.empty_free_list) begin
+        end else if (ir_cu_i.empty_free_list || ir_cu_i.simd_empty_free_list || ir_cu_i.fp_empty_free_list) begin
             pipeline_ctrl_o.stall_iq  = 1'b1;
             pipeline_ctrl_o.stall_ir  = 1'b0;
             pipeline_ctrl_o.stall_rr  = 1'b0;

--- a/rtl/datapath/rtl/datapath.sv
+++ b/rtl/datapath/rtl/datapath.sv
@@ -616,10 +616,11 @@ assign debug_reg_o.rnm_read_resp = stage_no_stall_rr_q.prs1;
         .new_register_o         (simd_free_register_to_rename),
         .checkpoint_o           (simd_checkpoint_free_list),
         .out_of_checkpoints_o   (simd_out_of_checkpoints_free_list),
-        .empty_o                (simd_free_list_empty) // TODO not connected
+        .empty_o                (simd_free_list_empty)
     );
     `else
     assign simd_free_register_to_rename = 'h0;
+    assign simd_free_list_empty = 1'b0;
     `endif
 
     free_list #(
@@ -640,7 +641,7 @@ assign debug_reg_o.rnm_read_resp = stage_no_stall_rr_q.prs1;
         .new_register_o         (fp_free_register_to_rename),
         .checkpoint_o           (fp_checkpoint_free_list),
         .out_of_checkpoints_o   (fp_out_of_checkpoints_free_list),
-        .empty_o                (fp_free_list_empty) // TODO not connected
+        .empty_o                (fp_free_list_empty)
     );
 
     // Rename Table
@@ -768,6 +769,8 @@ assign debug_reg_o.rnm_read_resp = stage_no_stall_rr_q.prs1;
     // Signals for Control Unit
     assign ir_cu_int.valid                   = stage_iq_ir_q.instr.valid;
     assign ir_cu_int.empty_free_list         = free_list_empty;
+    assign ir_cu_int.simd_empty_free_list    = simd_free_list_empty;
+    assign ir_cu_int.fp_empty_free_list      = fp_free_list_empty;
     assign ir_cu_int.out_of_checkpoints      = out_of_checkpoints_rename;
     assign ir_cu_int.simd_out_of_checkpoints = simd_out_of_checkpoints_rename;
     assign ir_cu_int.fp_out_of_checkpoints   = fp_out_of_checkpoints_rename;


### PR DESCRIPTION
Closes #3.

This PR wires the `simd_free_list_empty` and `fp_free_list_empty` signals to the control unit to trigger an IQ stall when physical registers are exhausted.

**Changes:**
1. Added `simd_empty_free_list` and `fp_empty_free_list` to `ir_cu_t` struct in `drac_pkg.sv`.
2. Wired signals in `datapath.sv` and removed `// TODO not connected` comments.
3. Added SIMD/FP signals alongside scalar `empty_free_list` in `control_unit.sv` stall/flush conditions (lines 424, 490).

**Verification:**
- The fix strictly follows the existing scalar `empty_free_list` pattern.
- `make lint` requires Verilator which is not available in this environment. The changes are syntactically straightforward (struct fields + wiring + OR conditions), exactly mirroring the proven scalar implementation.

Let me know if there is a specific testbench target I should run for SIMD register exhaustion.