### PR TITLE
Document HPM event 40 and external HPM events 41-50

### DIFF
--- a/events.md
+++ b/events.md
@@ -41,6 +41,7 @@ Each of the 29 generic performance counters can be configured to count events fr
 37. DCache uncached request
 38. DCache read request miss
 39. DCache write request miss
+40. Stalls of Register Rename
 
 **This mapping is done in the file top_drac.sv**
 

--- a/events.md
+++ b/events.md
@@ -43,6 +43,25 @@ Each of the 29 generic performance counters can be configured to count events fr
 39. DCache write request miss
 40. Stalls of Register Rename
 
+When the `EXTERNAL_HPM_EVENT_NUM` compile-time macro is defined, the following
+additional events are available depending on its value (supported
+configurations are `4`, `6`, and `10`):
+
+| Event | Available when `EXTERNAL_HPM_EVENT_NUM` is | Source |
+| --- | --- | --- |
+| 41 | 4, 6, or 10 | L2 miss |
+| 42 | 4, 6, or 10 | L2 access |
+| 43 | 4, 6, or 10 | L1.5 miss |
+| 44 | 4, 6, or 10 | L1.5 access |
+| 45 | 6 | NOC-S flit valid |
+| 46 | 6 | NOC-S stall |
+| 45 | 10 | NOC flit valid, channel 0 |
+| 46 | 10 | NOC flit valid, channel 1 |
+| 47 | 10 | NOC flit valid, channel 2 |
+| 48 | 10 | NOC stall, channel 0 |
+| 49 | 10 | NOC stall, channel 1 |
+| 50 | 10 | NOC stall, channel 2 |
+
 **This mapping is done in the file top_drac.sv**
 
 Event 0 is hardwired to always zero, as per the spec.


### PR DESCRIPTION
### Summary

- document HPM event 40: stalls in the register-rename stage
- restore documentation for the external HPM events (41-50) exposed through the `EXTERNAL_HPM_EVENT_NUM` compile-time macro, including which configurations (4, 6, 10) expose each event

### Why

`top_drac.sv` maps `pmu_flags.stall_ir` to HPM event 40, while `events.md`
previously stopped at event 39. In addition, the external PMU/HPM events
wired in via `EXTERNAL_HPM_EVENT_NUM` (L2/L1.5 access and miss, NOC flow and
stall events) were undocumented. Per review feedback on #7, the
configuration-validation RTL was dropped and only the documentation is kept.

### Impact

Users configuring hardware performance counters can identify and select the
register-rename stall event and the external L2/L1.5/NOC events correctly.

### Validation

- verified each documentation entry against the event mapping block in
  `rtl/top_drac.sv` (events 41-44 for any supported width, 45-46 for width 6,
  45-50 for width 10)
- documentation-only change; no HDL behavior changes

Related to #7