### PR TITLE
Add missing HPM event 40 (Rename stalls) to events.md

### DIFF
--- a/events.md
+++ b/events.md
@@ -41,6 +41,7 @@ Each of the 29 generic performance counters can be configured to count events fr
 37. DCache uncached request
 38. DCache read request miss
 39. DCache write request miss
+40. Stalls of Rename
 
 **This mapping is done in the file top_drac.sv**
 


### PR DESCRIPTION
While going through the HPM event mapping in `top_drac.sv` I noticed that `events.md` lists only 39 event sources, but the RTL actually maps 40:

```systemverilog
assign hpm_events_d[40] = pmu_flags.stall_ir;
```

`drac_pkg.sv` also defines `HPM_NUM_EVENTS = 40`, so it seems the doc just wasn't updated when the rename-stall event was added.

This PR adds the missing entry `40. Stalls of Rename` to the list.

Fixes #11