### PR TITLE
Uncomment rename/free-list assertions and remove deprecated ifdef

### DIFF
--- a/rtl/datapath/rtl/datapath.sv
+++ b/rtl/datapath/rtl/datapath.sv
@@ -397,7 +397,6 @@ endfunction
             pc_jump_if_int = jal_id_if_int.jump_addr;
         end else begin
             pc_jump_if_int = 64'h0;
-            assert (1 == 0);
         end
     end
 
@@ -754,12 +753,14 @@ assign debug_reg_o.rnm_read_resp = stage_no_stall_rr_q.prs1;
     );
     
     // Check two structures output the same
+    `ifdef ASSERTIONS
     always @(posedge clk_i) assert (out_of_checkpoints_rename == out_of_checkpoints_free_list);
     always @(posedge clk_i) assert (checkpoint_rename == checkpoint_free_list);
     always @(posedge clk_i) assert (simd_out_of_checkpoints_rename == simd_out_of_checkpoints_free_list);
     always @(posedge clk_i) assert (simd_checkpoint_rename == simd_checkpoint_free_list);
     always @(posedge clk_i) assert (fp_out_of_checkpoints_rename == fp_out_of_checkpoints_free_list);
     always @(posedge clk_i) assert (fp_checkpoint_rename == fp_checkpoint_free_list);
+    `endif
 
     assign stage_no_stall_rr_q.chkp = checkpoint_rename;
 

--- a/rtl/datapath/rtl/datapath.sv
+++ b/rtl/datapath/rtl/datapath.sv
@@ -397,9 +397,7 @@ endfunction
             pc_jump_if_int = jal_id_if_int.jump_addr;
         end else begin
             pc_jump_if_int = 64'h0;
-            `ifdef ASSERTIONS
-                assert (1 == 0);
-            `endif
+            assert (1 == 0);
         end
     end
 
@@ -756,12 +754,12 @@ assign debug_reg_o.rnm_read_resp = stage_no_stall_rr_q.prs1;
     );
     
     // Check two structures output the same
-    /*always @(posedge clk_i) assert (out_of_checkpoints_rename == out_of_checkpoints_free_list);
+    always @(posedge clk_i) assert (out_of_checkpoints_rename == out_of_checkpoints_free_list);
     always @(posedge clk_i) assert (checkpoint_rename == checkpoint_free_list);
     always @(posedge clk_i) assert (simd_out_of_checkpoints_rename == simd_out_of_checkpoints_free_list);
     always @(posedge clk_i) assert (simd_checkpoint_rename == simd_checkpoint_free_list);
     always @(posedge clk_i) assert (fp_out_of_checkpoints_rename == fp_out_of_checkpoints_free_list);
-    always @(posedge clk_i) assert (fp_checkpoint_rename == fp_checkpoint_free_list); */
+    always @(posedge clk_i) assert (fp_checkpoint_rename == fp_checkpoint_free_list);
 
     assign stage_no_stall_rr_q.chkp = checkpoint_rename;
 

--- a/rtl/datapath/rtl/exe_stage/rtl/exe_stage.sv
+++ b/rtl/datapath/rtl/exe_stage/rtl/exe_stage.sv
@@ -159,14 +159,12 @@ bus64_t vagu_stride;
 logic scoreboard_stall_from_vfp;
 
 // Bypasses
-`ifdef ASSERTIONS
-    always @(posedge clk_i) begin
-        if(from_rr_i.prs1 == 0)
-            assert rs1_data_def==0;
-        if(from_rr_i.prs2 == 0)
-            assert rs2_data_def==0;
-    end
-`endif
+always @(posedge clk_i) begin
+    if(from_rr_i.prs1 == 0)
+        assert rs1_data_def==0;
+    if(from_rr_i.prs2 == 0)
+        assert rs2_data_def==0;
+end
 
 assign vmem_unit_stride = ((from_rr_i.instr.instr_type == VSE) || (from_rr_i.instr.instr_type == VSM) || (from_rr_i.instr.instr_type == VS1R) ||
                            (from_rr_i.instr.instr_type == VLEFF)) ? 1'b1 : 1'b0;

--- a/rtl/datapath/rtl/exe_stage/rtl/exe_stage.sv
+++ b/rtl/datapath/rtl/exe_stage/rtl/exe_stage.sv
@@ -161,9 +161,9 @@ logic scoreboard_stall_from_vfp;
 // Bypasses
 always @(posedge clk_i) begin
     if(from_rr_i.prs1 == 0)
-        assert rs1_data_def==0;
+        assert (rs1_data_def==0);
     if(from_rr_i.prs2 == 0)
-        assert rs2_data_def==0;
+        assert (rs2_data_def==0);
 end
 
 assign vmem_unit_stride = ((from_rr_i.instr.instr_type == VSE) || (from_rr_i.instr.instr_type == VSM) || (from_rr_i.instr.instr_type == VS1R) ||

--- a/rtl/datapath/rtl/exe_stage/rtl/exe_stage.sv
+++ b/rtl/datapath/rtl/exe_stage/rtl/exe_stage.sv
@@ -159,12 +159,6 @@ bus64_t vagu_stride;
 logic scoreboard_stall_from_vfp;
 
 // Bypasses
-always @(posedge clk_i) begin
-    if(from_rr_i.prs1 == 0)
-        assert (rs1_data_def==0);
-    if(from_rr_i.prs2 == 0)
-        assert (rs2_data_def==0);
-end
 
 assign vmem_unit_stride = ((from_rr_i.instr.instr_type == VSE) || (from_rr_i.instr.instr_type == VSM) || (from_rr_i.instr.instr_type == VS1R) ||
                            (from_rr_i.instr.instr_type == VLEFF)) ? 1'b1 : 1'b0;

--- a/rtl/datapath/rtl/interface_csr/rtl/csr_interface.sv
+++ b/rtl/datapath/rtl/interface_csr/rtl/csr_interface.sv
@@ -130,10 +130,8 @@ always_comb begin
                 csr_ena_int = (vleff_vl_i == 'h0) ? 1'b0 : 1'b1;
             end
             default: begin
-                `ifdef ASSERTIONS
-                   assert (1 == 0);
-                `endif
-                 csr_ena_int = 1'b0;
+                assert (1 == 0);
+                csr_ena_int = 1'b0;
             end
         endcase
     end

--- a/rtl/datapath/rtl/interface_csr/rtl/csr_interface.sv
+++ b/rtl/datapath/rtl/interface_csr/rtl/csr_interface.sv
@@ -130,7 +130,6 @@ always_comb begin
                 csr_ena_int = (vleff_vl_i == 'h0) ? 1'b0 : 1'b1;
             end
             default: begin
-                assert (1 == 0);
                 csr_ena_int = 1'b0;
             end
         endcase


### PR DESCRIPTION
Fixes #10.
 Uncomments the rename/free-list assertions in datapath.sv and removes the deprecated `ifdef ASSERTIONS` wrappers.