### PR TITLE
Document missing Makefile recipes in Top_Makefile.md

### DIFF
--- a/doc/Top_Makefile.md
+++ b/doc/Top_Makefile.md
@@ -20,3 +20,15 @@ Current recipies
 * strict_lint:                                                                  
     This script will lint all the Verilog and sv files with Verilator until an error is found. No artifacts are generated.
     **Files with tb_ and wip_ as prefix are excluded even if extension is .v or .sv**  
+* local_spyglass:
+    It will run a local Spyglass lint analysis through the script
+    ```/scripts/local_spy.sh```
+* remote_spyglass:
+    It will run the Spyglass CI analysis through the script
+    ```/scripts/spyglass_ci.sh```
+* init:
+    It will configure git to use the repository hooks
+    (```git config core.hooksPath .githooks```), enabling the pre-commit hook.
+* questa:
+    It will run the Questasim CI flow through the script
+    ```/scripts/questa_ci.sh```


### PR DESCRIPTION
The top-level Makefile has six recipes (`lint`, `strict_lint`, `local_spyglass`, `remote_spyglass`, `init`, `questa`) but `doc/Top_Makefile.md` only described the first two.

This adds short descriptions for the remaining four, following the same style as the existing entries. `init` seemed worth documenting especially, since it's what enables the repo's pre-commit hook.

Fixes #15