### PR TITLE
Fix veri_lint.sh: compile required packages and skip third-party sources

### DIFF
--- a/scripts/veri_lint.sh
+++ b/scripts/veri_lint.sh
@@ -18,7 +18,7 @@ done < <(find ./ -depth -name "includes" -o -name "rtl")
 rtl_files=""
 while read file; do
     rtl_files=$rtl_files$file$'\n'
-done < <(find   \( ! -iname \tb_* -a ! -iname \wip_* -a ! -iname \*_pkg\* -a ! -path \*/tb* \) -and \( -iname \*.v -o -iname \*.vh -o -iname \*.sv \))
+done < <(find   \( ! -iname \tb_* -a ! -iname \wip_* -a ! -iname \*_pkg\* -a ! -path \*/tb* -a ! -path \*/common_cells/\* -a ! -path \*/fpu/src/\* -a ! -path \*/test/\* \) -and \( -iname \*.v -o -iname \*.vh -o -iname \*.sv \))
 #remove the last character, If not verilator will try to run without file name
 rtl_files=${rtl_files::-1}
 echo "Verilator lint only"
@@ -29,7 +29,7 @@ while read p; do
   #grep for warnings and errors and save it on a variable. Notice that sterr is 
   #required
   echo -e "$GREEN $p $NC"
-  (verilator --lint-only   includes/riscv_pkg.sv includes/drac_pkg.sv $include_dirs "$p"| grep 'warning\|error')2>&1 | tee -a $artifact 
+  (verilator --lint-only   rtl/common_cells/src/cf_math_pkg.sv rtl/datapath/rtl/exe_stage/rtl/fpu/src/fpnew_pkg.sv includes/riscv_pkg.sv rtl/mmu/includes/mmu_pkg.sv includes/drac_pkg.sv $include_dirs "$p"| grep 'warning\|error')2>&1 | tee -a $artifact 
 done <<< "$rtl_files"
 
 #check if there is an artifact, due to errors or warnings


### PR DESCRIPTION
`make lint` fails on a fresh clone because `veri_lint.sh` only compiles `riscv_pkg.sv` and `drac_pkg.sv`, while `drac_pkg.sv` references `fpnew_pkg` and several units import `mmu_pkg`. The `-I` dirs don't help since packages need to be compiled, not just discoverable.

Two changes:
- add `cf_math_pkg`, `fpnew_pkg` and `mmu_pkg` to the verilator invocation in dependency order
- exclude `common_cells`/cvfpu internal sources and their `test/` files from the file sweep — they are third-party libraries with their own CI, and some import packages (`ecc_pkg`, etc.) outside this repo's lint scope

Verified on Verilator 5.048 and 5.020: `PKGNODECL` / `Import package not found` errors go from hundreds to zero.

Note: after this change the lint no longer stops on `PKGNODECL`, but pre-existing `WIDTHEXPAND`/`ASCRANGE` warnings in `riscv_pkg`/`drac_pkg`/`fpnew_pkg` now surface. Those look like a separate issue and I've kept them out of scope here.

Fixes #22