### PR TITLE
Fix SELRANGE in `vf7_wrapper`: move VLEN/64 guard to generate level

### DIFF
--- a/rtl/datapath/rtl/exe_stage/rtl/simd/vf7_wrapper.sv
+++ b/rtl/datapath/rtl/exe_stage/rtl/simd/vf7_wrapper.sv
@@ -50,16 +50,23 @@ for (genvar i = 0; (i < (VLEN/32)); i++) begin : GEN_VF7
     bus64_t source_operand;
     bus64_t result;
 
-    always_comb begin
-        source_operand = '0;
-        result = '0;
-        if (sew_i == SEW_64) begin
-            if (i < (VLEN/64)) begin
-                // continous assignment here allowed
+    if (i < (VLEN/64)) begin : GEN_LOW_SECTOR
+        always_comb begin
+            source_operand = '0;
+            result = '0;
+            if (sew_i == SEW_64) begin
                 source_operand = src_i[(i*64) +: 64];
-            end 
-        end else begin
-            source_operand = src_i[i*32 +: 32];
+            end else begin
+                source_operand = {32'd0, src_i[i*32 +: 32]};
+            end
+        end
+    end else begin : GEN_HIGH_SECTOR
+        always_comb begin
+            source_operand = '0;
+            result = '0;
+            if (sew_i != SEW_64) begin
+                source_operand = {32'd0, src_i[i*32 +: 32]};
+            end
         end
     end
 


### PR DESCRIPTION
The GEN_VF7 genvar loop runs i over 0..(VLEN/32)-1, but the SEW_64 path sliced src_i[(i*64) +: 64], which is elaborated for every i and indexes outside src_i ([VLEN-1:0]) for i >= VLEN/64 (Verilator SELRANGE at i=2,3 under VLEN=128). Move the (i < VLEN/64) guard to a generate-level if so the 64-bit slice is only elaborated for valid lanes. The SEW_32 assignment is zero-extended explicitly to keep widths matched. Behaviour is unchanged.