### PR TITLE
fix(decoder): add missing default case to Zbb unary instruction decoder

### DIFF
--- a/rtl/datapath/rtl/id_stage/rtl/decoder.sv
+++ b/rtl/datapath/rtl/id_stage/rtl/decoder.sv
@@ -734,6 +734,9 @@ module decoder
                                         RS2_CPOPW: begin
                                             decode_instr_int.instr_type = CPOPW;
                                         end
+                                        default: begin
+                                            xcpt_illegal_instruction_int = 1'b1;
+                                        end
                                     endcase;
                                 end
                                 default: begin


### PR DESCRIPTION
closes #34 