### PR TITLE
fix(decoder): clear use_rs1 for VSETIVLI instruction

### DIFF
--- a/rtl/datapath/rtl/id_stage/rtl/decoder.sv
+++ b/rtl/datapath/rtl/id_stage/rtl/decoder.sv
@@ -2871,6 +2871,7 @@ module decoder
                                     decode_instr_int.instr_type = VSETIVLI;
                                     decode_instr_int.vl = vl_short;
                                     decode_instr_int.use_imm = 1'b1;
+                                    decode_instr_int.use_rs1 = 1'b0;
                                 end else begin
                                     xcpt_illegal_instruction_int = 1'b1;
                                 end


### PR DESCRIPTION
#45
Just a small proposed cleanup in `decoder.sv`: explicit setting `use_rs1 = 1'b0` for `VSETIVLI`. 
Since `vsetivli` uses an immediate instead of reading `rs1`, thought this might be good for decoder flag consistency.