### PR TITLE
Fix syntax error when `PHY_ADDR_SIZE` = 64 using static casting

### DIFF
--- a/includes/drac_pkg.sv
+++ b/includes/drac_pkg.sv
@@ -189,7 +189,7 @@ typedef struct packed {
 
 function automatic logic range_check(addr_t start_region, addr_t end_region, bus64_t address);
     // if len is a power of two, and base is properly aligned, this check could be simplified
-    return (address >= {{{64-PHY_VIRT_MAX_ADDR_SIZE}{1'b0}}, start_region}) && (address < {{{64-PHY_VIRT_MAX_ADDR_SIZE}{1'b0}}, end_region});
+    return (address >= bus64_t'(start_region)) && (address < bus64_t'(end_region));
 endfunction : range_check
 
 function automatic logic is_inside_IO_sections (drac_cfg_t Cfg, bus64_t address);


### PR DESCRIPTION
closes #61 