### PR TITLE
Remove legacy SFENCE encoding from SYSTEM decode

### DIFF
--- a/rtl/datapath/rtl/id_stage/rtl/decoder.sv
+++ b/rtl/datapath/rtl/id_stage/rtl/decoder.sv
@@ -3129,12 +3129,6 @@ module decoder
                                                         decode_instr_int.instr_type = WFI;
                                                         decode_instr_int.stall_csr_fence = 1'b1;
                                                     end
-                                                    RS2_EBREAK_SFENCEVM: begin
-                                                        // SFENCE here is old ISA
-                                                        // TODO (guillemlp): check and delete this option 
-                                                        decode_instr_int.instr_type = SFENCE_VMA;
-                                                        decode_instr_int.stall_csr_fence = 1'b1;
-                                                    end
                                                     default: begin
                                                         xcpt_illegal_instruction_int = 1'b1;
                                                     end 


### PR DESCRIPTION
Removes the `RS2_EBREAK_SFENCEVM` case from the `F7_SRET_WFI_ERET_SFENCE` branch, as discussed in #65. It carried a TODO noting it was the old ISA encoding, and since the current SFENCE.VMA (`funct7=0001001`) is decoded separately, the case only had the effect of accepting an undefined encoding. With it removed, the existing `default` raises the illegal-instruction exception.

Verified in `core_tile` (Verilator 5.048), using `riscv-tests/isa/rv64mi/illegal.S` with the first `.word` swapped:

| word | meaning | before | after |
|---|---|---|---|
| `0x00000000` | illegal (control) | trap | trap |
| `0x12000073` | SFENCE.VMA (`funct7=0001001`) | no trap | no trap |
| `0x10100073` | `funct7=0001000, rs2=00001` | no trap | **trap** |

ISA suite unchanged: 315 passed, 0 failed, 2 skipped — same as baseline on `main` (403975c).

Fixes #65