### PR TITLE
Reject reserved funct3=110 in the FCMP guard

### DIFF
--- a/rtl/datapath/rtl/id_stage/rtl/decoder.sv
+++ b/rtl/datapath/rtl/id_stage/rtl/decoder.sv
@@ -3418,7 +3418,7 @@ module decoder
                                 end
 
                                 // Check through rounding modes if illegal instr
-                                if (!(decode_i.inst.fprtype.rm inside {[3'b100:3'b110], [3'b000:3'b010]})) begin
+                                if (!(decode_i.inst.fprtype.rm inside {[3'b100:3'b101], [3'b000:3'b010]})) begin
                                     xcpt_illegal_instruction_int = 1'b1;
                                 end
                             end


### PR DESCRIPTION
Tightens the illegal-instruction guard for the `F5_FP_FCMP` group, as discussed in #64.

The accepted set was `{000, 001, 010, 100, 101, 110}`. For this funct5, funct3 selects the comparison: 000/001/010 are FLE/FLT/FEQ and 100/101 are the Zfa FLEQ/FLTQ; 011, 110 and 111 have no defined encoding. 011 and 111 were already rejected by the range bounds, but 110 passed the guard and was routed to the `FLEQ_FLTQ` path. Narrowing the upper bound to `3'b101` rejects it.

@SurbhiAgarwal1 independently confirmed the same reading against the spec in #64.

I wasn't able to isolate this at runtime — the FP test environments in my setup trap both the valid and the reserved encoding — so this rests on the encoding tables rather than a differential test.

ISA suite unchanged: 315 passed, 0 failed, 2 skipped — same as baseline on `main` (403975c).

Fixes #64